### PR TITLE
Fixed double forward slash.

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,7 +8,7 @@
 -->
 {% for post in site.posts %}
   <url>
-    <loc>{{ site.url }}{{ post.url }}.html</loc>
+    <loc>{{ site.url }}{{ post.url | remove_first "/"}}.html</loc>
     <!-- 
       This is for the embbed Google Search; 
       THe thumbnail will be shwon along side the post title in the
@@ -16,7 +16,7 @@
     -->
     <PageMap xmlns="http://www.google.com/schemas/sitemap-pagemap/1.0">
       <DataObject type="thumbnail">
-        <Attribute name="url">{{ site.url }}/assets/imgs/{{ post.url | split: "/" | last }}.png</Attribute>
+        <Attribute name="url">{{ site.url }}assets/imgs/{{ post.url | split: "/" | last }}.png</Attribute>
         <Attribute name="width">471</Attribute>
         <Attribute name="height">328</Attribute>
       </DataObject>


### PR DESCRIPTION
There were a double forward slash in the URL within the ```<loc>``` tag in sitemap.xml,